### PR TITLE
output will show number literals with '0b' and '0x' prefix 

### DIFF
--- a/scanner/src/lib.rs
+++ b/scanner/src/lib.rs
@@ -162,7 +162,7 @@ impl Scanner {
                     b'b' => {
                         // binary integer literal
                         let mut len =2;
-                        self.src.as_bytes()[self.offset..].iter().take_while(|&&c| c== b'0' || c == b'1')
+                        self.src.as_bytes()[self.offset + 2..].iter().take_while(|&&c| c== b'0' || c == b'1')
                         .for_each(|_|len+=1);
                     if len ==2{
                         //error expected at least one binary digit after 0b
@@ -178,7 +178,7 @@ impl Scanner {
                     b'x' | b'X' => {
                         // hex integer literal
                         let mut len =2;
-                        self.src.as_bytes()[self.offset..].iter().take_while(|&&c| c.is_ascii_hexdigit())
+                        self.src.as_bytes()[self.offset + 2..].iter().take_while(|&&c| c.is_ascii_hexdigit())
                         .for_each(|_|len+=1);
                     if len ==2{
                         //error expected at least one binary digit after 0x

--- a/scanner/src/lib.rs
+++ b/scanner/src/lib.rs
@@ -101,16 +101,20 @@ impl Scanner {
                 .map(|c| *c as char),
         )
     }
-    #[inline]
+   /*  #[inline]
     fn scan_binary_integer(&self) -> Literal {
         String::from_iter(
+            let len =2;
             self.src.as_bytes()[self.offset..]
                 .iter()
                 .take_while(|&&c| c == b'0' || c == b'1')
+                .for_each(|_| len+=1);
+
+
                 .map(|c: &u8|  *c as char),
         )
-    }
-    #[inline]
+    }*/
+   /*  #[inline]
     fn scan_hexadecimal_integer(&self) -> Literal {
         String::from_iter(
             self.src.as_bytes()[self.offset..]
@@ -118,7 +122,7 @@ impl Scanner {
                 .take_while(|&&c| c.is_ascii_hexdigit() )
                 .map(|c: &u8|  *c as char),
         )
-    }
+    }*/
     #[inline]
     fn scan_octal_integer(&self) -> Literal {
         String::from_iter(
@@ -157,17 +161,34 @@ impl Scanner {
                 match self.peek() {
                     b'b' => {
                         // binary integer literal
-                        self.advance(2); // Skip "0b"
-                        let lit = self.scan_binary_integer();
-                        return (Token::BINARY, pos, lit);
+                        let mut len =2;
+                        self.src.as_bytes()[self.offset..].iter().take_while(|&&c| c== b'0' || c == b'1')
+                        .for_each(|_|len+=1);
+                    if len ==2{
+                        //error expected at least one binary digit after 0b
+                        panic!("expected at least one binary digit after 0b");
+                    } 
+                    //let _lit =&self.src[self.offset..self.offset+len];
+                        
+                        self.advance(len);
+                        return (Token::BINARY, pos,self.src[self.offset..self.offset + len].to_string());
                     
                     }
 
                     b'x' | b'X' => {
                         // hex integer literal
-                        self.advance(2); // Skip "0x" or "0X"
-                        let lit = self.scan_hexadecimal_integer();
-                        return (Token::HEXADECIMAL, pos, lit);
+                        let mut len =2;
+                        self.src.as_bytes()[self.offset..].iter().take_while(|&&c| c.is_ascii_hexdigit())
+                        .for_each(|_|len+=1);
+                    if len ==2{
+                        //error expected at least one binary digit after 0x
+                        panic!("expected at least one binary digit after 0x");
+                    } 
+                    //let lit =&self.src[self.offset..self.offset+len];
+                        
+                        self.advance(len);
+                       
+                        return (Token::HEXADECIMAL, pos,self.src[self.offset..self.offset + len].to_string() );
                     
                     }
 
@@ -188,6 +209,7 @@ impl Scanner {
                     let lit = self.scan_integer();
                     self.advance(lit.len());
                     return (Token::DECIMAL, pos, lit);
+                    
 
                 // else integer literal
             
@@ -207,7 +229,7 @@ impl Scanner {
                 self.rd_offset = self.offset + 1;
                 self.ch = self.src.as_bytes()[self.offset];
 
-                return (Token::INTEGER, pos, lit);
+                return (Token::INTEGER, pos.clone(), lit);
             }
 
             b';' => (Token::SEMICOLON, (self.ch as char).to_string()),

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -15,6 +15,7 @@ pub enum Token {
     OCTAL,
     HEXADECIMAL,
     DECIMAL,
+
     FLOATING,
     STRING,
     literal_end,


### PR DESCRIPTION
According to the previous requirement changed the code to handle and display output with '0b' and '0x' prefix for binary and hexadecimal number literals.